### PR TITLE
deduplicate append prepend

### DIFF
--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -331,8 +331,18 @@ func NewMultiMergeAppendCommand() *cobra.Command {
 				existingBranches = append(existingBranches, reference.Name)
 			}
 
+			// Filter out branches already in manifest
+			newBranches, duplicates := filterDuplicateBranches(existingBranches, branches)
+			for _, dup := range duplicates {
+				fmt.Println(color.YellowString("%s is already in manifest, skipping", dup))
+			}
+			if len(newBranches) == 0 {
+				fmt.Println("No new branches to add")
+				return
+			}
+
 			// Append new branches to existing ones
-			allBranches := append(existingBranches, branches...)
+			allBranches := append(existingBranches, newBranches...)
 
 			_, err = repo.MultiMergeNamedBranches(target, allBranches)
 			handleMultiMergeError(err)

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -65,6 +65,23 @@ func checkOngoingMerge(repo *git.LocalRepository) error {
 	return nil
 }
 
+// filterDuplicateBranches returns branches from newBranches that are not already
+// in existingBranches. Also returns the list of duplicates found.
+func filterDuplicateBranches(existingBranches, newBranches []string) (filtered, duplicates []string) {
+	existing := make(map[string]bool, len(existingBranches))
+	for _, b := range existingBranches {
+		existing[b] = true
+	}
+	for _, b := range newBranches {
+		if existing[b] {
+			duplicates = append(duplicates, b)
+		} else {
+			filtered = append(filtered, b)
+		}
+	}
+	return filtered, duplicates
+}
+
 func branchNameCompletions(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	repo, err := git.GetLocalRepository()
 	if err != nil {

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -77,6 +77,7 @@ func filterDuplicateBranches(existingBranches, newBranches []string) (filtered, 
 			duplicates = append(duplicates, b)
 		} else {
 			filtered = append(filtered, b)
+			existing[b] = true
 		}
 	}
 	return filtered, duplicates

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -403,8 +403,18 @@ func NewMultiMergePrependCommand() *cobra.Command {
 				existingBranches = append(existingBranches, reference.Name)
 			}
 
+			// Filter out branches already in manifest
+			newBranches, duplicates := filterDuplicateBranches(existingBranches, branches)
+			for _, dup := range duplicates {
+				fmt.Println(color.YellowString("%s is already in manifest, skipping", dup))
+			}
+			if len(newBranches) == 0 {
+				fmt.Println("No new branches to add")
+				return
+			}
+
 			// Prepend new branches before existing ones
-			allBranches := append(branches, existingBranches...)
+			allBranches := append(newBranches, existingBranches...)
 
 			_, err = repo.MultiMergeNamedBranches(target, allBranches)
 			handleMultiMergeError(err)


### PR DESCRIPTION
## Summary

- `append` and `prepend` no longer allow duplicate branches — if a user supplies branches already in the manifest, each duplicate gets a yellow warning and is skipped
- If all supplied branches are duplicates, the command exits early without triggering a re-merge
- Duplicates within the user-supplied list itself (e.g. `-B foo -B foo`) are also caught

## Test plan

- `pila mm append -B <existing>` — warns and exits, no re-merge
- `pila mm append -B <existing> -B <new>` — warns about existing, merges with full list including new
- `pila mm prepend -B <existing>` — same warning behavior
- `pila mm append -B <new>` — no warning, normal behavior
- `pila mm append -B foo -B foo` — second foo is skipped as duplicate